### PR TITLE
Update environment.yml to use older version of pip

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.10
   - cudatoolkit=11.8
-  - pip
+  - pip==23.2.1
   - pip:
     - -f https://data.dgl.ai/wheels/cu117/repo.html
     - dgl<1.1.3


### PR DESCRIPTION
Resolved a compatibility issue in newer versions of pip:

`.* suffix can only be used with == or != operators`

Full log:

```
Pip subprocess error:
WARNING: Ignoring version 1.7.0 of pytorch-lightning since it has invalid metadata:
Requested pytorch-lightning==1.7.0 from https://files.pythonhosted.org/packages/2f/07/57fd85991eec4311b9945369158bca1322f801686d701322a65789852d46/pytorch_lightning-1.7.0-py3-none-any.whl (from -r /home/ronghaon/NODEJS_LLM/DeepDFA/condaenv.tepfgmak.requirements.txt (line 6)) has invalid metadata: .* suffix can only be used with `==` or `!=` operators
    torch (>=1.9.*)
           ~~~~~~^
Please use pip<24.1 if you need to use this version.
```